### PR TITLE
Remove unused _darwin-switch recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,28 +14,28 @@ This repository contains Diego's dotfiles, primarily focused on Nix-based system
 # List all available commands
 just
 
-# Auto-detect current machine and rebuild (main command)
-just nix-switch
+# Auto-detect current machine and rebuild (uses nh)
+just switch
 
 # Format nix files
-just nix-fmt
+just fmt
 
 # Check nix flake
-just nix-check
+just check
 
 # Quick format and check
-just nix-lint
+just lint
 
 # Update nix flake
-just nix-update
+just update
 
 # Garbage collect nix store
-just nix-gc
+just gc
 
-# Quick dry run for office-mbp
-just nix-dry-run
+# Quick dry run for the current host
+just dry-run
 
-# Use nix-home-manager for darwin switch
+# Run the nh-based switch command directly
 just nh-switch
 ```
 
@@ -99,8 +99,8 @@ cd bin && make uninstall
 ## Workflow
 
 1. Edit configuration files in the `nix/` directory
-2. Test changes with `just nix-check` or `just nix-dry-run`
-3. Apply changes with `just nix-switch`
+2. Test changes with `just check` or `just dry-run`
+3. Apply changes with `just switch`
 4. If needed, roll back with `darwin-rebuild --rollback`
 
 ## Troubleshooting

--- a/nix/README.org
+++ b/nix/README.org
@@ -16,7 +16,7 @@ A clean, modern macOS configuration using nix-darwin and Home Manager with flake
    Install Nix using the Determinate Systems installer:
 
    #+begin_src bash
-   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   just install-nix
    #+end_src
 
    Install just command runner:
@@ -54,13 +54,13 @@ A clean, modern macOS configuration using nix-darwin and Home Manager with flake
 ** Apply Changes Locally
 
    #+begin_src bash
-   # Auto-detect current machine and rebuild
-   just nix-switch
+   # Auto-detect current machine and rebuild using nh
+   just switch
 
    # Or target specific machines
-   just nix-rebuild office-mbp
-   just nix-rebuild personal-mbp
-   just nix-rebuild personal-mini
+   darwin-rebuild switch --flake .#office-mbp
+   darwin-rebuild switch --flake .#personal-mbp
+   darwin-rebuild switch --flake .#personal-mini
    #+end_src
 
    *Manual rebuild:*
@@ -77,13 +77,13 @@ A clean, modern macOS configuration using nix-darwin and Home Manager with flake
 
    #+begin_src bash
    # Format code
-   just nix-fmt
+   just fmt
    # Check configuration
-   just nix-check
+   just check
    # Update flake inputs
-   just nix-update
+   just update
    # Garbage collection
-   just nix-gc
+   just gc
    #+end_src
 
 ** Available Commands
@@ -177,7 +177,7 @@ A clean, modern macOS configuration using nix-darwin and Home Manager with flake
   *Clean up:*
 
   #+begin_src bash
-  just nix-gc      # Remove old generations
+  just gc      # Remove old generations
   #+end_src
 
   *Brew apps not in the Application folder:*


### PR DESCRIPTION
## Summary
- clean up the justfile by removing the unused `_darwin-switch` recipe
- make `dry-run` recipe respect `_host` variable so it works on any machine

## Testing
- `just --list`


------
https://chatgpt.com/codex/tasks/task_e_686b005b09bc832b80a5dd4cd6656a85