### PR TITLE
Provide non-nh switch fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,11 @@ This repository contains Diego's dotfiles, primarily focused on Nix-based system
 # List all available commands
 just
 
-# Auto-detect current machine and rebuild (uses nh)
+# Auto-detect current machine and rebuild (uses nh if installed)
 just switch
+
+# Rebuild using darwin-rebuild (fallback when nh isn't available)
+just darwin-switch
 
 # Format nix files
 just fmt
@@ -37,6 +40,8 @@ just dry-run
 
 # Run the nh-based switch command directly
 just nh-switch
+# Run the darwin-rebuild switch command directly
+just darwin-switch
 ```
 
 ### Manual Rebuild Commands

--- a/justfile
+++ b/justfile
@@ -73,7 +73,12 @@ install-darwin:
     sudo nix --extra-experimental-features nix-command --extra-experimental-features flakes run nix-darwin -- switch --flake ./nix#{{_host}}
 
 # Auto-detect current machine and rebuild (main command)
-switch: nh-switch
+switch:
+    if command -v nh > /dev/null; then
+    just nh-switch
+    else
+    just darwin-switch
+    fi
 
 # Quick dry run for the current host
 dry-run:
@@ -83,3 +88,7 @@ dry-run:
 nh-switch:
     @echo "🔍 Switching host {{_host}} with nh"
     nh darwin switch ./nix#darwinConfigurations.{{_host}}
+
+darwin-switch:
+    @echo "🔍 Switching host {{_host}} with darwin-rebuild"
+    darwin-rebuild switch --flake ./nix#{{_host}}

--- a/nix/README.org
+++ b/nix/README.org
@@ -54,8 +54,11 @@ A clean, modern macOS configuration using nix-darwin and Home Manager with flake
 ** Apply Changes Locally
 
    #+begin_src bash
-   # Auto-detect current machine and rebuild using nh
-   just switch
+    # Auto-detect current machine and rebuild using nh if available
+    just switch
+
+    # Manually rebuild using darwin-rebuild
+    just darwin-switch
 
    # Or target specific machines
    darwin-rebuild switch --flake .#office-mbp


### PR DESCRIPTION
## Summary
- add fallback logic to `just switch` that calls `darwin-rebuild` when `nh` isn't present
- document new `darwin-switch` recipe in `CLAUDE.md` and `nix/README.org`

## Testing
- `just check` *(fails: `nix` not found)*
- `just fmt` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687546812ba8832b8b0453a92394650b