### PR TITLE
chore: remove unused GPG configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,8 +49,8 @@ All machines use Apple Silicon (aarch64-darwin) and auto-detect based on usernam
 - *Window Management:* AeroSpace tiling window manager
 - *Status Bar:* SketchyBar with custom plugins
 - *CLI Tools:* ripgrep, fd, bat, jq, yq, eza, and many more
-- *Dev Tools:* Git with GPG signing, GitHub CLI, Docker, kubectl
-- *Secrets:* sops-nix with GPG encryption
+- *Dev Tools:* Git with SSH signing (via 1Password), GitHub CLI, Docker, kubectl
+- *Secrets:* 1Password CLI for on-demand secret access
 - *AI Tools:* Claude Code with custom agents
 
 * Common Commands

--- a/nix/home-manager/config/environment.nix
+++ b/nix/home-manager/config/environment.nix
@@ -34,9 +34,6 @@
     # Spell checker for emacs
     ASPELL_CONF = "dict-dir ${pkgs.aspellDicts.en}/lib/aspell";
 
-    # macOS-specific environment variables
-    GPG_TTY = "${builtins.getEnv "TTY"}";
-
     # Active profile for conditional scripts
     PROFILE = profile;
 

--- a/nix/home-manager/config/programs.nix
+++ b/nix/home-manager/config/programs.nix
@@ -149,35 +149,5 @@
             };
           };
       };
-
-    # GPG configuration - DISABLED (no longer needed, using SSH signing)
-    # gpg = {
-    #   enable = true;
-    #   settings = {
-    #     auto-key-retrieve = true;
-    #     no-emit-version = true;
-    #     default-key = "4DF4C58193BBB0863AB37A6DC63945863D4B9E77";
-    #     encrypt-to = "4DF4C58193BBB0863AB37A6DC63945863D4B9E77";
-    #   };
-    # };
   };
-
-  # ============================================================================
-  # Services
-  # ============================================================================
-
-  # services = {
-  #   # GPG Agent service - DISABLED (no longer needed)
-  #   # Run once: `gpg --decrypt ~/.authinfo.gpg` to save it in keychain
-  #   gpg-agent = {
-  #     enable = true;
-  #     defaultCacheTtl = 43200;
-  #     enableSshSupport = true;
-  #     enableZshIntegration = true;
-  #     enableFishIntegration = true;
-  #     maxCacheTtl = 86400;
-  #     # macOS-specific pinentry
-  #     pinentry.package = pkgs.pinentry_mac;
-  #   };
-  # };
 }

--- a/nix/profiles/base.nix
+++ b/nix/profiles/base.nix
@@ -158,7 +158,6 @@ let
     # aerospace # Window manager (installed via Homebrew cask)
     jankyborders # Window borders
     mas # Mac App Store
-    pinentry_mac # GPG pinentry for macOS
   ];
 in
 {

--- a/nix/systems/darwin/system/programs.nix
+++ b/nix/systems/darwin/system/programs.nix
@@ -10,7 +10,6 @@ _:
       enable = true;
       enableCompletion = false; # Disable here, let home-manager handle it
     };
-    gnupg.agent.enable = false; # Disabled - using Home Manager GPG agent instead
     fish.enable = true;
   };
 }


### PR DESCRIPTION
## Summary

GPG was replaced by SSH signing via 1Password. Remove all remnants:

- Delete commented GPG/gpg-agent config in programs.nix
- Remove `GPG_TTY` env var from environment.nix  
- Remove `pinentry_mac` package from base.nix
- Remove `gnupg.agent.enable` from system programs.nix
- Update README.org to reflect SSH signing and 1Password

## Test plan

- [x] `nix flake check` passes
- [ ] `just switch` applies cleanly

Assisted-by: Opus 4.5 via Claude Code